### PR TITLE
Ensure MITM flow prepares TLS certificates before server launch

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,6 +1,7 @@
 # launcher.py
 import os, sys, time, subprocess, socket, shlex
 import config
+from certs import ensure_server_certs
 
 def start_server_console(mode: str, keylog_path: str | None, port: int, new_console: bool = True):
     args = [sys.executable, "server.py", "--mode", mode, "--port", str(port)]
@@ -73,6 +74,10 @@ def start_mitm_chat(pin: str | None = None):
     Demo 4: run MITM without pinning
     Demo 5: run MITM with certificate pinning (pass pin)
     """
+    try:
+        ensure_server_certs()
+    except SystemExit as exc:
+        raise RuntimeError("Failed to prepare TLS server certificates") from exc
     # 1. Start real server
     start_server_console("tls", None, config.PORT_SERVER_REAL)
     wait_for_port(config.HOST, config.PORT_SERVER_REAL)


### PR DESCRIPTION
## Summary
- centralize TLS/MITM certificate preparation so demos abort cleanly if setup fails
- make MITM launcher verify the TLS server certificate exists before starting the real server

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cddbd2865083209f44942f702c26cc