### PR TITLE
force: prefer TLS1.3 (fallback to TLS1.2) for client/server/mitm

### DIFF
--- a/client.py
+++ b/client.py
@@ -147,6 +147,11 @@ def main():
     sock.settimeout(0.2)  # allow quick exit on Ctrl+C/Q
     if use_tls:
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        # Prefer TLS1.3 for lab captures; fallback to TLS1.2 if unavailable.
+        try:
+            context.minimum_version = ssl.TLSVersion.TLSv1_3
+        except AttributeError:
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if args.insecure:
             print("[Client] ⚠️ Certificate verification disabled (--insecure).")

--- a/mitm.py
+++ b/mitm.py
@@ -39,6 +39,11 @@ def handle_client(client_tls):
 
         # TLS context for connecting to real server
         server_ctx = ssl.create_default_context()
+        # Prefer TLS1.3 for lab captures; fallback to TLS1.2 if unavailable.
+        try:
+            server_ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+        except AttributeError:
+            server_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         server_ctx.check_hostname = False
         server_ctx.verify_mode = ssl.CERT_NONE
 
@@ -60,6 +65,11 @@ def main():
     args = parser.parse_args()
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # Prefer TLS1.3 for lab captures; fallback to TLS1.2 if unavailable.
+    try:
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+    except AttributeError:
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
     ensure_mitm_certs()
     context.load_cert_chain(certfile="mitm.crt", keyfile="mitm.key")
 

--- a/server.py
+++ b/server.py
@@ -154,6 +154,11 @@ def main():
     context = None
     if use_tls:
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        # Prefer TLS1.3 for lab captures; fallback to TLS1.2 if unavailable.
+        try:
+            context.minimum_version = ssl.TLSVersion.TLSv1_3
+        except AttributeError:
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.load_cert_chain(certfile="server.crt", keyfile="server.key")
         if args.keylog:
             context.keylog_filename = args.keylog


### PR DESCRIPTION
## Summary
- enforce TLS 1.3 as the preferred minimum for client connections, with TLS 1.2 fallback if TLS 1.3 is unavailable
- require TLS 1.3 (with TLS 1.2 fallback) for server-side contexts in the chat server and MITM utility
- apply the same TLS minimum version policy to the MITM client's outbound context to maintain lab capture compatibility

## Testing
- python - <<'PY'
import ssl, socket, threading, time

HOST = '127.0.0.1'
PORT = 8443

server_ready = threading.Event()
server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
try:
    server_context.minimum_version = ssl.TLSVersion.TLSv1_3
except AttributeError:
    server_context.minimum_version = ssl.TLSVersion.TLSv1_2
server_context.load_cert_chain('server.crt', 'server.key')

client_context = ssl.create_default_context()
try:
    client_context.minimum_version = ssl.TLSVersion.TLSv1_3
except AttributeError:
    client_context.minimum_version = ssl.TLSVersion.TLSv1_2
client_context.check_hostname = False
client_context.verify_mode = ssl.CERT_NONE

negotiated_version = None


def run_server():
    global negotiated_version
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        sock.bind((HOST, PORT))
        sock.listen(1)
        server_ready.set()
        conn, addr = sock.accept()
        with server_context.wrap_socket(conn, server_side=True) as ssock:
            negotiated_version = ssock.version()
            time.sleep(0.5)

thread = threading.Thread(target=run_server)
thread.start()

server_ready.wait()

with socket.create_connection((HOST, PORT)) as sock:
    with client_context.wrap_socket(sock, server_hostname='localhost') as ssock:
        print('Client negotiated TLS version:', ssock.version())

thread.join()
print('Server negotiated TLS version:', negotiated_version)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ceaf4ffbf483208b586823846f7922