### PR TITLE
docs: add openssl s_client & Wireshark cheat-sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Inspecting TLS 1.3 handshake
+
+When you start the TLS chat demo with key logging enabled, the launcher writes
+secrets to `/workspace/Lab2-7075/tls_keys.log` (the value of
+`os.path.abspath(config.KEYLOG_FILENAME)`). TLS 1.3 is preferred for this lab,
+though the `-tls1_3` flag may fail if your OpenSSL build does not support it.
+
+## Wireshark
+- Open a capture and configure **TLS → (Pre)-Master-Secret log file** to point to
+  `/workspace/Lab2-7075/tls_keys.log`.
+- Filter example: `tcp.port == 12345`.
+
+## openssl s_client
+```bash
+openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -showcerts
+openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -msg -state
+```

--- a/TLSSecureChat.py
+++ b/TLSSecureChat.py
@@ -173,7 +173,25 @@ def run_selection(sel: int) -> None:
         keylog_path = os.path.abspath(keylog)
         open(keylog_path, "a", encoding="utf-8").close()
         print(Fore.YELLOW + f"TLS key logging ENABLED: {keylog_path}")
-        print(Fore.YELLOW + "Wireshark → Preferences → Protocols → TLS → Pre-Master-Secret log filename\n")
+        print(
+            Fore.YELLOW
+            + "Wireshark → Preferences → Protocols → TLS → Pre-Master-Secret log filename"
+        )
+        print(
+            Fore.YELLOW
+            + f"Open a capture in Wireshark; set TLS → (Pre)-Master-Secret log file to: {keylog_path}"
+        )
+        print(Fore.YELLOW + "Wireshark filter example: tcp.port == 12345")
+        print(
+            Fore.YELLOW
+            + "openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -showcerts"
+        )
+        print(
+            Fore.YELLOW
+            + "To view session details: openssl s_client -connect 127.0.0.1:12345 -servername "
+            "localhost -tls1_3 -msg -state"
+        )
+        print()
 
     # Dramatic flair ✨
     print()


### PR DESCRIPTION
## Summary
- expand the TLS key logging menu hints with Wireshark filtering and openssl s_client examples
- document the TLS 1.3 inspection workflow, including key log path and CLI commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb6f65998832090a85597da8437a0