### PR TITLE
Ensure TLS certificates validate on Mininet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ though the `-tls1_3` flag may fail if your OpenSSL build does not support it.
 openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -showcerts
 openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -msg -state
 ```
+
+## Mininet TLS tips
+
+The bundled `server.crt` now includes Subject Alternative Names for both
+`127.0.0.1` and `10.0.0.1` and is marked as a trust anchor so that the TLS demo
+works on Mininet out of the box.  If you generated certificates before pulling
+this change, delete `server.crt`/`server.key` (or re-run the helper below) so
+the new SAN entries are added:
+
+```bash
+python3 -c "from certs import ensure_server_certs; ensure_server_certs()"
+```


### PR DESCRIPTION
## Summary
- update the generated TLS server certificate template to include 10.0.0.1 and mark it as a trust anchor
- automatically regenerate outdated certificates that lack the Mininet SAN entry
- document how to refresh certificates so the TLS chat demo works on Mininet

## Testing
- python3 -m compileall certs.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a7e79e208320be1826749d977ef2