### PR TITLE
Add host configuration options for MITM proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,23 @@ though the `-tls1_3` flag may fail if your OpenSSL build does not support it.
 openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -showcerts
 openssl s_client -connect 127.0.0.1:12345 -servername localhost -tls1_3 -msg -state
 ```
+
+## MITM proxy host configuration
+
+The proxy (`mitm.py`) accepts two host-related CLI flags:
+
+- `--listen-host` controls which interface the proxy binds to (defaults to
+  `0.0.0.0`).
+- `--server-host` controls which host the proxy connects to for the real TLS
+  server (defaults to `config.HOST`).
+
+For single-machine demos you can keep the defaults.  In Mininet, launch the
+proxy on the attacker node with the node's data-plane IP, for example:
+
+```bash
+python mitm.py --listen-host 10.0.0.3 --server-host 10.0.0.1
+```
+
+When using `launcher_mininet.py`, override the defaults by exporting
+`TLSCHAT_MITM_LISTEN` (proxy listen address) and `TLSCHAT_SERVER_HOST` (real
+server address) before starting the launcher.

--- a/launcher.py
+++ b/launcher.py
@@ -196,11 +196,21 @@ def start_mitm_chat(pin: str | None = None) -> None:
     wait_for_port(config.HOST, config.PORT_SERVER_REAL)
 
     # 2. Start MITM proxy
+    mitm_listen_host = config.HOST
     subprocess.Popen(
-        [sys.executable, "mitm.py", "--port", str(config.PORT_SERVER_MITM)],
+        [
+            sys.executable,
+            "mitm.py",
+            "--port",
+            str(config.PORT_SERVER_MITM),
+            "--listen-host",
+            mitm_listen_host,
+            "--server-host",
+            config.HOST,
+        ],
         cwd=os.getcwd()
     )
-    wait_for_port(config.HOST, config.PORT_SERVER_MITM)
+    wait_for_port(mitm_listen_host, config.PORT_SERVER_MITM)
 
     # 3. Start client (connects to MITM, with optional pinning)
     start_client_console("tls", None, config.PORT_SERVER_MITM, pin=pin)

--- a/launcher_mininet.py
+++ b/launcher_mininet.py
@@ -3,6 +3,9 @@ import os
 import sys
 import subprocess
 
+DEFAULT_SERVER_HOST = os.environ.get("TLSCHAT_SERVER_HOST", "10.0.0.1")
+DEFAULT_MITM_LISTEN_HOST = os.environ.get("TLSCHAT_MITM_LISTEN", "0.0.0.0")
+
 # Define the demo options
 DEMO_OPTIONS = [
     "Plain chat (no TLS)",
@@ -76,7 +79,23 @@ def launch_script(role, args):
                 cmd += ["--pin", "dummyfingerprint"]
             cmd += list(args["extras"])
     elif script == "mitm.py":
-        cmd += ["--port", "23456"]
+        cmd += [
+            "--port",
+            "23456",
+            "--listen-host",
+            os.environ.get("TLSCHAT_MITM_LISTEN", DEFAULT_MITM_LISTEN_HOST),
+            "--server-host",
+            os.environ.get("TLSCHAT_SERVER_HOST", DEFAULT_SERVER_HOST),
+        ]
+
+    if script == "mitm.py":
+        listen_host = os.environ.get("TLSCHAT_MITM_LISTEN", DEFAULT_MITM_LISTEN_HOST)
+        server_host = os.environ.get("TLSCHAT_SERVER_HOST", DEFAULT_SERVER_HOST)
+        print(
+            "\n[Info] MITM proxy will listen on"
+            f" {listen_host}:23456 and connect to {server_host}:12345."
+        )
+        print("[Info] Override defaults by setting TLSCHAT_MITM_LISTEN or TLSCHAT_SERVER_HOST.")
 
     print(f"\nLaunching: {' '.join(cmd)}\n")
     subprocess.run(cmd)

--- a/mitm.py
+++ b/mitm.py
@@ -18,8 +18,6 @@ from certs import ensure_mitm_certs
 
 STOP = threading.Event()
 
-HOST = "127.0.0.1"
-
 def relay(src, dst, name):
     """Relay decrypted data between sockets while optionally logging it.
 
@@ -62,11 +60,12 @@ def relay(src, dst, name):
         try: dst.close()
         except: pass
 
-def handle_client(client_tls):
+def handle_client(client_tls, real_host):
     """Accept a victim TLS session and bridge it to the real server.
 
     Args:
       client_tls: TLS-wrapped socket from the victim client.
+      real_host: Hostname or IP address of the real TLS server.
 
     Returns:
       None.
@@ -83,8 +82,8 @@ def handle_client(client_tls):
     """
 
     try:
-        #print(f"[MITM] Connecting to real server {HOST}:{config.PORT_SERVER_REAL}")
-        real_sock = socket.create_connection((HOST, config.PORT_SERVER_REAL))
+        #print(f"[MITM] Connecting to real server {real_host}:{config.PORT_SERVER_REAL}")
+        real_sock = socket.create_connection((real_host, config.PORT_SERVER_REAL))
 
         # TLS context for connecting to real server
         server_ctx = ssl.create_default_context()
@@ -102,7 +101,7 @@ def handle_client(client_tls):
         # Second TLS handshake (proxy -> real server).  If this fails the MITM
         # cannot observe plaintext but the client still believes it connected to
         # the intended host because of the forged certificate.
-        real_tls = server_ctx.wrap_socket(real_sock, server_hostname="localhost")
+        real_tls = server_ctx.wrap_socket(real_sock, server_hostname=real_host)
         # print("[MITM] TLS handshake with real server successful")
 
         # Start bidirectional relay (decrypted streams)
@@ -135,7 +134,12 @@ def main():
     """
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--port", type=int, default=config.PORT_SERVER_MITM)
+    parser.add_argument("--port", type=int, default=config.PORT_SERVER_MITM,
+                        help="Port for the proxy to listen on")
+    parser.add_argument("--listen-host", default="0.0.0.0",
+                        help="Interface/IP for the proxy listener (default: 0.0.0.0)")
+    parser.add_argument("--server-host", default=config.HOST,
+                        help="Real server host/IP to connect to (default: config.HOST)")
     args = parser.parse_args()
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -149,8 +153,8 @@ def main():
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        #print(f"[MITM] Binding on {HOST}:{args.port}")
-        s.bind((HOST, args.port))
+        #print(f"[MITM] Binding on {args.listen_host}:{args.port}")
+        s.bind((args.listen_host, args.port))
         s.listen(5)
         #print(f"[MITM] Listening on {args.port}, forwarding to {config.PORT_SERVER_REAL}")
 
@@ -163,7 +167,7 @@ def main():
                 # validation or trusts the rogue certificate.
                 client_tls = context.wrap_socket(client_sock, server_side=True)
                 #print("[MITM] TLS handshake with client successful")
-                threading.Thread(target=handle_client, args=(client_tls,), daemon=True).start()
+                threading.Thread(target=handle_client, args=(client_tls, args.server_host), daemon=True).start()
             except Exception as e:
                 #print("[MITM] Handshake with client failed:", e)
                 client_sock.close()


### PR DESCRIPTION
## Summary
- add CLI flags to the MITM proxy to configure the listen interface and upstream server host
- update the launchers to forward the new options and document how to configure hosts for Mininet

## Testing
- python -m compileall mitm.py launcher.py launcher_mininet.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b676d9248320bc825f796151a50c