### PR TITLE
Add host controls for client and Mininet launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ proxy on the attacker node with the node's data-plane IP, for example:
 python mitm.py --listen-host 10.0.0.3 --server-host 10.0.0.1
 ```
 
-When using `launcher_mininet.py`, override the defaults by exporting
-`TLSCHAT_MITM_LISTEN` (proxy listen address) and `TLSCHAT_SERVER_HOST` (real
-server address) before starting the launcher.
+When using `launcher_mininet.py`, export the following environment variables on
+each Mininet host before launching the menu so the helper picks the right
+targets automatically:
+
+- `TLSCHAT_SERVER_HOST` / `TLSCHAT_SERVER_PORT` for the real server used in
+  demos 1–3 (defaults: `config.HOST` and `config.PORT_SERVER`).
+- `TLSCHAT_MITM_HOST` / `TLSCHAT_MITM_PORT` for the MITM endpoint the client
+  should dial during demos 4–5 (defaults: inherits from
+  `TLSCHAT_MITM_LISTEN` or falls back to the server host, and
+  `config.PORT_SERVER_MITM`).
+- `TLSCHAT_MITM_LISTEN` for the interface where the proxy should bind.
+
+The chat client itself now accepts a `--host` flag (defaulting to
+`config.HOST`).  The Mininet launcher will pass the appropriate host and port
+automatically based on the selected demo.

--- a/client.py
+++ b/client.py
@@ -295,7 +295,16 @@ def main():
     install_graceful_crash_handler()
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", choices=["tls", "plain"], default="tls")
-    parser.add_argument("--keylog", help="Path to write TLS key log (for Wireshark decryption)", default=None)
+    parser.add_argument(
+        "--host",
+        default=config.HOST,
+        help="Host to connect to (defaults to config.HOST)",
+    )
+    parser.add_argument(
+        "--keylog",
+        help="Path to write TLS key log (for Wireshark decryption)",
+        default=None,
+    )
     parser.add_argument("--port", type=int, default=config.PORT_SERVER, help="Port to connect/bind to")
     parser.add_argument("--cafile", help="Path to a CA bundle or server certificate for verification", default=None)
     parser.add_argument("--insecure", action="store_true",
@@ -314,7 +323,7 @@ def main():
 
     snap_console()
 
-    HOST = "10.0.0.1"
+    HOST = args.host
     PORT = args.port
     use_tls = (args.mode == "tls")
 
@@ -384,7 +393,7 @@ def main():
             # The TLS handshake happens within ``wrap_socket``.  On success the
             # returned object is ready for encrypted I/O; failures surface
             # certificate or protocol issues to the user.
-            ssock = context.wrap_socket(sock, server_hostname="localhost")
+            ssock = context.wrap_socket(sock, server_hostname=HOST)
         except ssl.SSLCertVerificationError as exc:
             sock.close()
             graceful_exit(

--- a/launcher_mininet.py
+++ b/launcher_mininet.py
@@ -3,8 +3,16 @@ import os
 import sys
 import subprocess
 
-DEFAULT_SERVER_HOST = os.environ.get("TLSCHAT_SERVER_HOST", "10.0.0.1")
+import config
+
+DEFAULT_SERVER_HOST = os.environ.get("TLSCHAT_SERVER_HOST", config.HOST)
+DEFAULT_SERVER_PORT = int(os.environ.get("TLSCHAT_SERVER_PORT", config.PORT_SERVER))
 DEFAULT_MITM_LISTEN_HOST = os.environ.get("TLSCHAT_MITM_LISTEN", "0.0.0.0")
+DEFAULT_MITM_HOST = os.environ.get(
+    "TLSCHAT_MITM_HOST",
+    DEFAULT_MITM_LISTEN_HOST if DEFAULT_MITM_LISTEN_HOST != "0.0.0.0" else DEFAULT_SERVER_HOST,
+)
+DEFAULT_MITM_PORT = int(os.environ.get("TLSCHAT_MITM_PORT", config.PORT_SERVER_MITM))
 
 # Define the demo options
 DEMO_OPTIONS = [
@@ -71,7 +79,16 @@ def launch_script(role, args):
     cmd = [sys.executable, script]
 
     if script == "server.py" or script == "client.py":
-        cmd += ["--mode", args["mode"], "--port", "12345"]
+        cmd += ["--mode", args["mode"]]
+        if script == "client.py":
+            target_host = DEFAULT_SERVER_HOST
+            target_port = DEFAULT_SERVER_PORT
+            if args["mitm"]:
+                target_host = DEFAULT_MITM_HOST
+                target_port = DEFAULT_MITM_PORT
+            cmd += ["--host", str(target_host), "--port", str(target_port)]
+        else:
+            cmd += ["--port", str(DEFAULT_SERVER_PORT)]
         if args["keylog"]:
             cmd += ["--keylog", args["keylog"]]
         if script == "client.py":
@@ -81,7 +98,7 @@ def launch_script(role, args):
     elif script == "mitm.py":
         cmd += [
             "--port",
-            "23456",
+            str(DEFAULT_MITM_PORT),
             "--listen-host",
             os.environ.get("TLSCHAT_MITM_LISTEN", DEFAULT_MITM_LISTEN_HOST),
             "--server-host",
@@ -91,11 +108,18 @@ def launch_script(role, args):
     if script == "mitm.py":
         listen_host = os.environ.get("TLSCHAT_MITM_LISTEN", DEFAULT_MITM_LISTEN_HOST)
         server_host = os.environ.get("TLSCHAT_SERVER_HOST", DEFAULT_SERVER_HOST)
+        client_host = os.environ.get("TLSCHAT_MITM_HOST", DEFAULT_MITM_HOST)
         print(
             "\n[Info] MITM proxy will listen on"
-            f" {listen_host}:23456 and connect to {server_host}:12345."
+            f" {listen_host}:{DEFAULT_MITM_PORT} and connect to {server_host}:{DEFAULT_SERVER_PORT}."
         )
-        print("[Info] Override defaults by setting TLSCHAT_MITM_LISTEN or TLSCHAT_SERVER_HOST.")
+        print(
+            f"[Info] Clients targeting the MITM demos will connect to {client_host}:{DEFAULT_MITM_PORT}."
+        )
+        print(
+            "[Info] Override defaults by setting TLSCHAT_MITM_LISTEN, "
+            "TLSCHAT_SERVER_HOST, TLSCHAT_MITM_HOST, or TLSCHAT_MITM_PORT."
+        )
 
     print(f"\nLaunching: {' '.join(cmd)}\n")
     subprocess.run(cmd)


### PR DESCRIPTION
## Summary
- add a --host flag to the chat client so the target host is configurable and used for SNI
- teach the Mininet launcher to pass direct-server or MITM host/port settings based on the demo selection
- refresh the README with guidance on the new environment variables and client flag

## Testing
- python -m compileall client.py launcher_mininet.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b7b9430c8320b6d6fdae81f34016